### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
   def index
-    # @items = Item.all 次回使用
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,7 +156,7 @@
     <% end %> 
 
     <%# 商品がない場合は以下のダミー商品を表示 %>
-    <% if @items = nil %>
+    <% if @items.length == 0 %>
     <li class='list'>
       <%= link_to '#' do %>
       <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-    <%# <% @items.each do |item|  次回使用 %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%# <%= image_tag item.image, class: "item-img" 次回使用%> 
+          <%= image_tag item.image, class: "item-img" %> 
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <%# <div class='sold-out'>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%# <%= "#{item.name}" 次回使用 %> 
+            <%= "#{item.name}"  %> 
           </h3>
           <div class='item-price'>
-            <%# <span><%= "#{item.price}" 円<br><%= "#{item.charge.name}" </span> 次回使用%>
+            <span><%= "#{item.price}" %>円<br><%= "#{item.charge.name}" %> </span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,7 +153,7 @@
         </div>
         <% end %>
       </li>
-    <%# <% end 次回使用%> 
+    <% end %> 
 
     <%# 商品がない場合は以下のダミー商品を表示 %>
     <% if @items = nil %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Item, type: :model do
       it 'category_idは1では登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Category must be other than 1"
+        expect(@item.errors.full_messages).to include 'Category must be other than 1'
       end
       it 'situation_idが空では登録できない' do
         @item.situation_id = ''
@@ -51,7 +51,7 @@ RSpec.describe Item, type: :model do
       it 'situation_idは1では登録できない' do
         @item.situation_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Situation must be other than 1"
+        expect(@item.errors.full_messages).to include 'Situation must be other than 1'
       end
       it 'shopping_day_idが空では登録できない' do
         @item.shopping_day_id = ''
@@ -61,7 +61,7 @@ RSpec.describe Item, type: :model do
       it 'shopping_day_idは1では登録できない' do
         @item.shopping_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Shopping day must be other than 1"
+        expect(@item.errors.full_messages).to include 'Shopping day must be other than 1'
       end
       it 'area_idが空では登録できない' do
         @item.area_id = ''
@@ -71,7 +71,7 @@ RSpec.describe Item, type: :model do
       it 'area_idは1では登録できない' do
         @item.area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Area must be other than 1"
+        expect(@item.errors.full_messages).to include 'Area must be other than 1'
       end
       it 'charge_idが空では登録できない' do
         @item.charge_id = ''
@@ -81,7 +81,7 @@ RSpec.describe Item, type: :model do
       it 'charge_idは1では登録できない' do
         @item.charge_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Charge must be other than 1"
+        expect(@item.errors.full_messages).to include 'Charge must be other than 1'
       end
       it 'priceが空では登録できない' do
         @item.price = ''
@@ -91,27 +91,27 @@ RSpec.describe Item, type: :model do
       it 'piceが300以下では登録できない' do
         @item.price = 250
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not included in the list"
+        expect(@item.errors.full_messages).to include 'Price is not included in the list'
       end
       it 'priceが9,999,999以上では登録できない' do
         @item.price = 100_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not included in the list"
+        expect(@item.errors.full_messages).to include 'Price is not included in the list'
       end
       it 'priceは全角数字では登録できない' do
-        @item.price = "２５０"
+        @item.price = '２５０'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not a number"
+        expect(@item.errors.full_messages).to include 'Price is not a number'
       end
       it 'priceは半角英語では登録できない' do
-        @item.price = "abcd"
+        @item.price = 'abcd'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not a number"
+        expect(@item.errors.full_messages).to include 'Price is not a number'
       end
       it 'priceは半角英数混合では登録できない' do
-        @item.price = "12ab"
+        @item.price = '12ab'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not a number"
+        expect(@item.errors.full_messages).to include 'Price is not a number'
       end
       it 'imageが空では登録できない' do
         @item.image = nil


### PR DESCRIPTION
## What
商品一覧表示機能の実装

## Why
出品した商品の一覧を表示するため
商品購入機能実装前に商品一覧表示機能を実装しているため、soldout機能は実装していません。

___出品された商品一覧表示が見ることができること___
https://gyazo.com/7600cb918c6fd3f0a50050398ec3e1b1

___ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること___
https://gyazo.com/a4b8a75e5b10df5f86d829471f0ddd73

___商品のデータがない場合に、ダミー商品が表示されている動画___
https://gyazo.com/936b25652c45bdeae4109f325b9e9f16